### PR TITLE
Supprimer le cadre parental et centrer sur le mini jeu

### DIFF
--- a/src/components/CompassGame.jsx
+++ b/src/components/CompassGame.jsx
@@ -26,6 +26,10 @@ const ID_TO_LABEL = QUADRANTS.reduce((acc, q) => {
 const MAX_TURNS = 10;
 const WIN_SCORE = 12; // Seuil de victoire
 const CATEGORIES = ['Liberté', 'Cœur', 'Règles', 'Sécurité'];
+const MIN_PLAYERS = 2;
+const MAX_PLAYERS = 15;
+const PLAYERS_STORAGE_KEY = 'compass-game.players.v1';
+const DEFAULT_PLAYER_PREFIX = 'Joueur';
 
 // Banque de questions (exemples fournis)
 const QUESTIONS = {
@@ -86,8 +90,6 @@ export default function CompassGame() {
   const [players, setPlayers] = useState([
     { name: 'Joueur 1', score: 0 },
     { name: 'Joueur 2', score: 0 },
-    { name: 'Joueur 3', score: 0 },
-    { name: 'Joueur 4', score: 0 },
   ]);
   const [activePlayerIndex, setActivePlayerIndex] = useState(0);
   const [turn, setTurn] = useState(1);


### PR DESCRIPTION
Implement player management (2-15 players), a "ronde des décisions" QCM, and retro-futuristic medieval UI icons.

The QCM now appears when the compass lands on a boundary, requiring player input before the game proceeds to the next turn. Player names are persisted in local storage.

---
<a href="https://cursor.com/background-agent?bcId=bc-6bcbeac0-147b-4948-b690-b00781df0894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6bcbeac0-147b-4948-b690-b00781df0894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

